### PR TITLE
feat(auth): improve accessibility and localization

### DIFF
--- a/lib/core/constants/auth_constants.dart
+++ b/lib/core/constants/auth_constants.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 class AuthConstants {
   // Colors
   static const Color backgroundDark = Color(0xFF0F172A);
-  static const Color backgroundLight = Color(0xFFF8FAFC);
+  static const Color backgroundLight = Color(0xFFF1F8FA);
   static const Color textPrimaryDark = Color(0xFF1E293B);
   static const Color accentBlue = Color(0xFF60A5FA);
   static const Color accentGreen = Color(0xFF00C853);

--- a/lib/features/auth/screens/forgot_password_screen.dart
+++ b/lib/features/auth/screens/forgot_password_screen.dart
@@ -150,6 +150,7 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen>
                       AuthSectionTitle(
                         icon: Icons.email_outlined,
                         title: t.resetPassword,
+                        iconColor: AppColors.primaryBlue,
                       ),
                       const SizedBox(height: AuthConstants.spacingLarge),
                       buildErrorMessage(_errorMessage),
@@ -157,6 +158,7 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen>
                       CustomTextField(
                         label: t.emailOrPhone,
                         controller: _emailOrPhoneController,
+                        hint: t.forgotPasswordHint,
                         validator: (value) {
                           if (value == null || value.isEmpty) {
                             return t.fieldRequired;
@@ -169,21 +171,22 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen>
                         },
                       ),
                       const SizedBox(height: AuthConstants.spacingLarge),
-                      CustomButton(
-                        text: t.send,
-                        onPressed: _isLoading ? null : _handleSubmit,
-                        isLoading: _isLoading,
-                        icon: Icons.send,
-                      ),
-                      const SizedBox(height: AuthConstants.spacingLarge),
-                      CustomButton.secondary(
-                        text: t.backToLogin,
-                        onPressed: () => context.pop(),
-                        icon: Icons.arrow_back,
-                      ),
                     ],
                   ),
                 ),
+              ),
+              const SizedBox(height: AuthConstants.spacingLarge),
+              CustomButton(
+                text: t.send,
+                onPressed: _isLoading ? null : _handleSubmit,
+                isLoading: _isLoading,
+                icon: Icons.send,
+              ),
+              const SizedBox(height: AuthConstants.spacingLarge),
+              CustomButton.secondary(
+                text: t.backToLogin,
+                onPressed: () => context.pop(),
+                icon: Icons.arrow_back,
               ),
               const SizedBox(height: AuthConstants.spacingLarge),
             ],

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -122,12 +122,12 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: SafeArea(
         child: SingleChildScrollView(
-          padding: AuthConstants.paddingAll16,
+          padding: AuthConstants.paddingAll24,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               AuthLogoHeader(isDark: isDark, subtitle: t.welcomeMessage),
-              const SizedBox(height: AuthConstants.spacingLarge),
+              const SizedBox(height: AuthConstants.spacingSmall),
               AuthFloatingCard(
                 isFormCard: true,
                 child: Form(
@@ -136,6 +136,8 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       buildErrorMessage(_authState.errorMessage),
+                      const SizedBox(height: AuthConstants.buttonSpacing),
+
                       CustomTextField.phone(
                         label: t.phoneNumber,
                         hint: t.phoneNumberHint,
@@ -162,7 +164,6 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
                               _formData = _formData.copyWith(password: value);
                             }),
                       ),
-                      const SizedBox(height: AuthConstants.spacingSmall),
                       Align(
                         alignment: Alignment.centerRight,
                         child: TextButton(
@@ -189,7 +190,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
               // Action buttons outside the card
               Column(
                 children: [
-                  CustomButton(
+                  CustomButton.primary(
                     text: t.login,
                     onPressed: _authState.isLoading ? null : _handleLogin,
                     isLoading: _authState.isLoading,

--- a/lib/features/auth/screens/splash_screen.dart
+++ b/lib/features/auth/screens/splash_screen.dart
@@ -131,7 +131,12 @@ class _SplashScreenState extends ConsumerState<SplashScreen>
             mainAxisSize: MainAxisSize.min,
             children: [
               // Logo image
-              AuthLogoHeader(isDark: isDark, subtitle: message),
+              AuthLogoHeader(
+                isDark: isDark,
+                subtitle: message,
+                width: 170,
+                height: 120,
+              ),
             ],
           ),
         );

--- a/lib/features/auth/widgets/auth_floating_card.dart
+++ b/lib/features/auth/widgets/auth_floating_card.dart
@@ -3,19 +3,6 @@ import 'package:flutter/material.dart';
 import '../../../core/constants/auth_constants.dart';
 import '../../../core/theme/app_colors.dart';
 
-/// A reusable floating card widget with gradient background and shadow effects.
-///
-/// This widget creates a visually appealing card with customizable styling,
-/// commonly used in authentication screens to group related content. It supports
-/// different visual styles based on theisPrimary] and [isFormCard] parameters.
-///
-/// Example usage:
-/// ```dart
-/// AuthFloatingCard(
-///   isPrimary: true,
-///   child: Text('Card content),
-/// )
-/// ```
 class AuthFloatingCard extends StatelessWidget {
   /// The content to display inside the card.
   final Widget child;
@@ -65,7 +52,7 @@ class AuthFloatingCard extends StatelessWidget {
 
     return Container(
       width: double.infinity,
-      padding: padding ?? AuthConstants.floatingCardPadding,
+      padding: padding ?? AuthConstants.paddingAll16,
       margin: margin,
       decoration: BoxDecoration(
         gradient: LinearGradient(

--- a/lib/features/auth/widgets/auth_logo_header.dart
+++ b/lib/features/auth/widgets/auth_logo_header.dart
@@ -13,6 +13,12 @@ class AuthLogoHeader extends StatelessWidget {
   /// This determines which logo asset to display and text colors to use.
   final bool isDark;
 
+  /// Optional custom width for the logo
+  final double? width;
+
+  /// Optional custom height for the logo
+  final double? height;
+
   /// Creates an AuthLogoHeader widget.
   ///
   /// The [isDark] parameter is required and determines the theme-appropriate
@@ -22,6 +28,8 @@ class AuthLogoHeader extends StatelessWidget {
     this.title,
     this.subtitle,
     required this.isDark,
+    this.width,
+    this.height,
   });
 
   @override
@@ -30,9 +38,9 @@ class AuthLogoHeader extends StatelessWidget {
       children: [
         Image.asset(
           isDark ? AuthConstants.logoDarkAsset : AuthConstants.logoAsset,
-          width: AuthConstants.logoWidth,
-          height: AuthConstants.logoHeight,
-          fit: BoxFit.cover,
+          width: width ?? AuthConstants.logoWidth,
+          height: height ?? AuthConstants.logoHeight,
+          fit: BoxFit.fitWidth,
         ),
         if (title != null) ...[
           Text(
@@ -55,7 +63,7 @@ class AuthLogoHeader extends StatelessWidget {
                   isDark
                       ? AuthConstants.darkSubtitleColor
                       : AuthConstants.lightSubtitleColor,
-              fontSize: 22,
+              fontSize: 20,
               fontWeight: FontWeight.w500,
             ),
             textAlign: TextAlign.center,

--- a/lib/features/auth/widgets/auth_section_title.dart
+++ b/lib/features/auth/widgets/auth_section_title.dart
@@ -4,14 +4,24 @@ import '../../../core/constants/auth_constants.dart';
 class AuthSectionTitle extends StatelessWidget {
   final IconData icon;
   final String title;
+  final Color? iconColor;
 
-  const AuthSectionTitle({super.key, required this.icon, required this.title});
+  const AuthSectionTitle({
+    super.key,
+    required this.icon,
+    required this.title,
+    this.iconColor,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Row(
       children: [
-        Icon(icon, color: Theme.of(context).primaryColor, size: 24),
+        Icon(
+          icon,
+          color: iconColor ?? Theme.of(context).primaryColor,
+          size: 24,
+        ),
         const SizedBox(width: AuthConstants.spacingSmall),
         Text(
           title,

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -589,11 +589,11 @@
   "@accessibilitySettings": {
     "description": "Title for the accessibility settings card"
   },
-  "voiceFeedbackEnabled": "التعليقات الصوتية مفعلة",
+  "voiceFeedbackEnabled": "مفعلة",
   "@voiceFeedbackEnabled": {
     "description": "Indicates that voice feedback is enabled"
   },
-  "voiceFeedbackDisabled": "التعليقات الصوتية معطلة",
+  "voiceFeedbackDisabled": "معطلة",
   "@voiceFeedbackDisabled": {
     "description": "Indicates that voice feedback is disabled"
   },
@@ -708,5 +708,13 @@
   "termsUpdateNotice": "قد يتم تحديث هذه الشروط من وقت لآخر. الاستخدام المستمر للتطبيق يشكل قبولاً لأي تغييرات.",
   "@termsUpdateNotice": {
     "description": "Description for terms update notice"
+  },
+  "systemThemeHint": "يتكيف تلقائيًا مع الوضع الفاتح أو الداكن في هاتفك.",
+  "@systemThemeHint": {
+    "description": "تلميح لخيار مظهر النظام في إعدادات إمكانية الوصول"
+  },
+  "forgotPasswordHint": "أدخل بريدك الإلكتروني أو رقم هاتفك",
+  "@forgotPasswordHint": {
+    "description": "تلميح لحقل البريد الإلكتروني أو الهاتف في شاشة نسيت كلمة المرور"
   }
 } 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -589,11 +589,11 @@
   "@accessibilitySettings": {
     "description": "Title for the accessibility settings card"
   },
-  "voiceFeedbackEnabled": "Voice feedback enabled",
+  "voiceFeedbackEnabled": "Enabled",
   "@voiceFeedbackEnabled": {
     "description": "Indicates that voice feedback is enabled"
   },
-  "voiceFeedbackDisabled": "Voice feedback disabled",
+  "voiceFeedbackDisabled": "Disabled",
   "@voiceFeedbackDisabled": {
     "description": "Indicates that voice feedback is disabled"
   },
@@ -708,5 +708,13 @@
   "termsUpdateNotice": "These terms may be updated from time to time. Continued use of the app constitutes acceptance of any changes.",
   "@termsUpdateNotice": {
     "description": "Description for terms update notice"
+  },
+  "systemThemeHint": "Automatically adapts to your phone's light or dark theme.",
+  "@systemThemeHint": {
+    "description": "Hint for system theme option in accessibility settings"
+  },
+  "forgotPasswordHint": "Enter your email or phone",
+  "@forgotPasswordHint": {
+    "description": "Hint for the email or phone input in the forgot password screen"
   }
 } 

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -589,11 +589,11 @@
   "@accessibilitySettings": {
     "description": "Title for the accessibility settings card"
   },
-  "voiceFeedbackEnabled": "Retour vocal activé",
+  "voiceFeedbackEnabled": "Activé",
   "@voiceFeedbackEnabled": {
     "description": "Indicates that voice feedback is enabled"
   },
-  "voiceFeedbackDisabled": "Retour vocal désactivé",
+  "voiceFeedbackDisabled": "Désactivé",
   "@voiceFeedbackDisabled": {
     "description": "Indicates that voice feedback is disabled"
   },
@@ -708,5 +708,13 @@
   "termsUpdateNotice": "Ces conditions peuvent être mises à jour de temps à autre. L'utilisation continue de l'application constitue l'acceptation de tout changement.",
   "@termsUpdateNotice": {
     "description": "Description for terms update notice"
+  },
+  "systemThemeHint": "S’adapte automatiquement au thème clair ou sombre de votre téléphone.",
+  "@systemThemeHint": {
+    "description": "Astuce pour l'option thème système dans les paramètres d'accessibilité"
+  },
+  "forgotPasswordHint": "Entrez votre email ou téléphone",
+  "@forgotPasswordHint": {
+    "description": "Astuce pour le champ email ou téléphone dans l'écran mot de passe oublié"
   }
 } 

--- a/lib/shared/widgets/access/accessibility_controls.dart
+++ b/lib/shared/widgets/access/accessibility_controls.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart' as intl;
 
@@ -13,10 +14,11 @@ class AccessibilityControls extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
+    final t = AppLocalizations.of(context)!;
     final locale = Localizations.localeOf(context);
     final isRtl = intl.Bidi.isRtlLanguage(locale.languageCode);
     final cardColor =
-        isDark ? const Color(0xFF232B33) : const Color(0xFFF1F8FA);
+        isDark ? const Color(0xFF232B33) : const Color(0xFFFFFFFF);
     final borderColor = isDark ? Colors.grey[800]! : Colors.grey.shade300;
     const activeColor = Color(0xFF2140D2);
     final inactiveColor = isDark ? Colors.grey[500]! : Colors.grey[400]!;
@@ -29,9 +31,45 @@ class AccessibilityControls extends ConsumerWidget {
     final isVoiceEnabled = ref.watch(voiceFeedbackProvider);
 
     final languages = [
-      {'name': 'Français', 'flag': '🇫🇷', 'code': 'fr', 'country': 'FR'},
-      {'name': 'Arabe', 'flag': '🇸🇦', 'code': 'ar', 'country': 'TU'},
-      {'name': 'English', 'flag': '🇬🇧', 'code': 'en', 'country': 'GB'},
+      {
+        'name':
+            t.language == 'Langue'
+                ? 'Français'
+                : t.language == 'Language'
+                ? 'French'
+                : t.language == 'اللغة'
+                ? 'الفرنسية'
+                : 'Français',
+        'flag': '🇫🇷',
+        'code': 'fr',
+        'country': 'FR',
+      },
+      {
+        'name':
+            t.language == 'Langue'
+                ? 'Arabe'
+                : t.language == 'Language'
+                ? 'Arabic'
+                : t.language == 'اللغة'
+                ? 'العربية'
+                : 'Arabic',
+        'flag': '🇹🇳',
+        'code': 'ar',
+        'country': 'TU',
+      },
+      {
+        'name':
+            t.language == 'Langue'
+                ? 'Anglais'
+                : t.language == 'Language'
+                ? 'English'
+                : t.language == 'اللغة'
+                ? 'الإنجليزية'
+                : 'English',
+        'flag': '🇺🇸',
+        'code': 'en',
+        'country': 'US',
+      },
     ];
     final selectedLang = languages.firstWhere(
       (l) => l['code'] == currentLocale.languageCode,
@@ -53,10 +91,8 @@ class AccessibilityControls extends ConsumerWidget {
               BoxShadow(
                 color:
                     isDark
-                        ? Colors.black.withAlpha(
-                                  (0.1 * 255).toInt())
-                        : Colors.black.withAlpha(
-                                  (0.04 * 255).toInt()),
+                        ? Colors.black.withAlpha((0.1 * 255).toInt())
+                        : Colors.black.withAlpha((0.04 * 255).toInt()),
                 blurRadius: 12,
                 offset: const Offset(0, 4),
               ),
@@ -67,7 +103,7 @@ class AccessibilityControls extends ConsumerWidget {
             children: [
               // Title
               Text(
-                'Configuration initiale',
+                t.accessibilitySettings,
                 style: theme.textTheme.headlineSmall?.copyWith(
                   fontSize: 24,
                   fontWeight: FontWeight.w600,
@@ -161,7 +197,7 @@ class AccessibilityControls extends ConsumerWidget {
               const SizedBox(height: 20),
               // Font Size
               Text(
-                'Taille du texte',
+                t.fontSize,
                 style: theme.textTheme.bodyLarge?.copyWith(
                   fontWeight: FontWeight.w600,
                   fontSize: 16,
@@ -183,20 +219,28 @@ class AccessibilityControls extends ConsumerWidget {
                                 ? activeColor
                                 : fieldColor,
                         foregroundColor:
-                            fontSize == FontSizeNotifier.normalSize
+                            isDark
                                 ? Colors.white
-                                : activeColor,
+                                : (fontSize == FontSizeNotifier.normalSize
+                                    ? Colors.white
+                                    : Colors.black),
                         side: const BorderSide(color: activeColor),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(12),
                         ),
                         elevation: 0,
                       ),
-                      child: const Text(
-                        'Normal',
+                      child: Text(
+                        t.normal,
                         style: TextStyle(
                           fontWeight: FontWeight.w600,
                           fontSize: 16,
+                          color:
+                              isDark
+                                  ? Colors.white
+                                  : (fontSize == FontSizeNotifier.normalSize
+                                      ? Colors.white
+                                      : Colors.black),
                         ),
                       ),
                     ),
@@ -214,20 +258,28 @@ class AccessibilityControls extends ConsumerWidget {
                                 ? activeColor
                                 : fieldColor,
                         foregroundColor:
-                            fontSize == FontSizeNotifier.largeSize
+                            isDark
                                 ? Colors.white
-                                : activeColor,
+                                : (fontSize == FontSizeNotifier.largeSize
+                                    ? Colors.white
+                                    : Colors.black),
                         side: const BorderSide(color: activeColor),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(12),
                         ),
                         elevation: 0,
                       ),
-                      child: const Text(
-                        'Grande',
+                      child: Text(
+                        t.large,
                         style: TextStyle(
                           fontWeight: FontWeight.w600,
                           fontSize: 16,
+                          color:
+                              isDark
+                                  ? Colors.white
+                                  : (fontSize == FontSizeNotifier.largeSize
+                                      ? Colors.white
+                                      : Colors.black),
                         ),
                       ),
                     ),
@@ -237,7 +289,7 @@ class AccessibilityControls extends ConsumerWidget {
               const SizedBox(height: 20),
               // Theme
               Text(
-                'Thème',
+                t.theme,
                 style: theme.textTheme.bodyLarge?.copyWith(
                   fontWeight: FontWeight.w600,
                   fontSize: 16,
@@ -275,7 +327,7 @@ class AccessibilityControls extends ConsumerWidget {
               const SizedBox(height: 20),
               // Voice feedback
               Text(
-                'Retour vocal',
+                t.voiceFeedback,
                 style: theme.textTheme.bodyLarge?.copyWith(
                   fontWeight: FontWeight.w600,
                   fontSize: 16,
@@ -299,14 +351,22 @@ class AccessibilityControls extends ConsumerWidget {
                   children: [
                     Icon(
                       isVoiceEnabled ? Icons.volume_up : Icons.volume_off,
-                      color: isVoiceEnabled ? activeColor : inactiveColor,
+                      color:
+                          isVoiceEnabled
+                              ? (isDark ? Colors.white : Colors.black)
+                              : inactiveColor,
                       size: 22,
                     ),
                     const SizedBox(width: 8),
                     Text(
-                      isVoiceEnabled ? 'Activé' : 'Désactivé',
+                      isVoiceEnabled
+                          ? t.voiceFeedbackEnabled
+                          : t.voiceFeedbackDisabled,
                       style: TextStyle(
-                        color: isVoiceEnabled ? activeColor : inactiveColor,
+                        color:
+                            isVoiceEnabled
+                                ? (isDark ? Colors.white : Colors.black)
+                                : inactiveColor,
                         fontWeight: FontWeight.w700,
                         fontSize: 17,
                       ),
@@ -339,17 +399,20 @@ Widget _buildThemeButton(
   Color activeColor,
   Color fieldColor,
 ) {
-  final labels = ['Clair', 'Sombre', 'Système'];
+  final t = AppLocalizations.of(context)!;
+  final labels = [t.light, t.dark, t.system];
   final modes = [ThemeMode.light, ThemeMode.dark, ThemeMode.system];
   final isSelected = currentTheme == modes[index];
   final isSystem = index == 2;
+  final isDark = Theme.of(context).brightness == Brightness.dark;
 
   return ElevatedButton(
     onPressed:
         () => ref.read(themeModeProvider.notifier).setThemeMode(modes[index]),
     style: ElevatedButton.styleFrom(
       backgroundColor: isSelected ? activeColor : fieldColor,
-      foregroundColor: isSelected ? Colors.white : activeColor,
+      foregroundColor:
+          isDark ? Colors.white : (isSelected ? Colors.white : Colors.black),
       side: BorderSide(color: activeColor),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       elevation: 0,
@@ -364,30 +427,41 @@ Widget _buildThemeButton(
             Icon(
               Icons.nightlight_round,
               size: 18,
-              color: isSelected ? Colors.white : activeColor,
+              color:
+                  isDark
+                      ? Colors.white
+                      : (isSelected ? Colors.white : Colors.black),
             ),
           if (index == 0) const SizedBox(width: 6),
           Text(
             labels[index],
-            style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 16),
+            style: TextStyle(
+              fontWeight: FontWeight.w600,
+              fontSize: 16,
+              color:
+                  isDark
+                      ? Colors.white
+                      : (isSelected ? Colors.white : Colors.black),
+            ),
           ),
           if (isSystem) ...[
             const SizedBox(width: 4),
             GestureDetector(
               onTap: () {
                 ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(
-                    content: Text(
-                      'S’adapte automatiquement au thème clair ou sombre de votre téléphone.',
-                    ),
-                    duration: Duration(seconds: 4),
+                  SnackBar(
+                    content: Text(t.systemThemeHint),
+                    duration: const Duration(seconds: 4),
                   ),
                 );
               },
               child: Icon(
                 Icons.info_outline,
                 size: 16,
-                color: isSelected ? Colors.white : activeColor,
+                color:
+                    isDark
+                        ? Colors.white
+                        : (isSelected ? Colors.white : Colors.black),
               ),
             ),
           ],

--- a/lib/shared/widgets/buttons/custom_button.dart
+++ b/lib/shared/widgets/buttons/custom_button.dart
@@ -153,7 +153,7 @@ class CustomButton extends StatelessWidget {
           elevation: 0,
           padding:
               padding ??
-              const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+              const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
           shape: RoundedRectangleBorder(
             borderRadius: borderRadius ?? BorderRadius.circular(12),
           ),
@@ -221,6 +221,7 @@ class CustomButton extends StatelessWidget {
                         style: Theme.of(context).textTheme.labelLarge?.copyWith(
                           color: contentColor,
                           fontWeight: FontWeight.w600,
+                          fontSize: 20,
                         ),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
@@ -239,6 +240,7 @@ class CustomButton extends StatelessWidget {
                         style: Theme.of(context).textTheme.labelLarge?.copyWith(
                           color: contentColor,
                           fontWeight: FontWeight.w600,
+                          fontSize: 20,
                         ),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
@@ -258,6 +260,7 @@ class CustomButton extends StatelessWidget {
           style: Theme.of(context).textTheme.labelLarge?.copyWith(
             color: contentColor,
             fontWeight: FontWeight.w600,
+            fontSize: 20,
           ),
           textAlign: TextAlign.center,
           maxLines: 2,

--- a/lib/shared/widgets/buttons/gradient_button.dart
+++ b/lib/shared/widgets/buttons/gradient_button.dart
@@ -184,7 +184,7 @@ class SecondaryGradientButton extends StatelessWidget {
                                 style: const TextStyle(
                                   color: Color(0xFF0092DF),
                                   fontWeight: FontWeight.bold,
-                                  fontSize: 16,
+                                  fontSize: 20,
                                   letterSpacing: 0.2,
                                 ),
                                 textAlign: TextAlign.center,


### PR DESCRIPTION
- Localized all user-facing text in the accessibility controls screen using AppLocalizations.
- Updated language flags and names (Arabic now uses Tunisia flag and 'Arabic', English uses US flag).
- Added support for custom logo size in splash screen only.
- Moved "Send" and "Back to Login" buttons outside the card in the forgot password screen.
- Localized the hint text in the forgot password input field with a dedicated key.
- Made the email icon in forgot password blue in all themes and added a localized hint.
- Unified button font sizes for consistent appearance across auth screens.