### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Build & Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/Saif-Yahyaoui/caredify/security/code-scanning/1](https://github.com/Saif-Yahyaoui/caredify/security/code-scanning/1)

To fix the problem, explicitly set the minimal required permissions for the `build` job. Since the `build` job does not perform any write operations, it is safe and recommended to set `permissions: contents: read` for this job. This can be done by adding a `permissions:` block with `contents: read` under the `build` job, at the same indentation level as `runs-on`. No additional methods or imports are required for this fix, just a small YAML edit. Only changes to `.github/workflows/build.yml` are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
